### PR TITLE
Fix version file URL property

### DIFF
--- a/GameData/WildBlueIndustries/ServoController/ServoController.version
+++ b/GameData/WildBlueIndustries/ServoController/ServoController.version
@@ -1,6 +1,6 @@
 {
     "NAME":"Kerbal Actuators: Servo Controller",
-    "URL":"https://raw.githubusercontent.com/Angel-125/ServoController/master/ServoController/GameData/WildBlueIndustries/ServoController/ServoController.version",
+    "URL":"https://raw.githubusercontent.com/Angel-125/ServoController/master/GameData/WildBlueIndustries/ServoController/ServoController.version",
     "DOWNLOAD":"https://github.com/Angel-125/ServoController/releases",
     "GITHUB":
     {


### PR DESCRIPTION
Hi @Angel-125!

The version file URL property is a 404:

https://raw.githubusercontent.com/Angel-125/ServoController/master/ServoController/GameData/WildBlueIndustries/ServoController/ServoController.version

There's an extra instance of the mod name after the branch name. Now it's fixed:

https://raw.githubusercontent.com/Angel-125/ServoController/master/GameData/WildBlueIndustries/ServoController/ServoController.version

Noticed while working on KSP-CKAN/NetKAN#8906.
Closes #1.